### PR TITLE
Add snoop as potential run option

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     - name: run tests
       run: |
         pip install -U pip
-        pip install --upgrade coveralls setuptools setuptools_scm pep517 snoop
+        pip install --upgrade coveralls setuptools setuptools_scm pep517
         pip install .[tests]
         coverage run --source python_runner -m pytest
         coverage report -m

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     - name: run tests
       run: |
         pip install -U pip
-        pip install --upgrade coveralls setuptools setuptools_scm pep517
+        pip install --upgrade coveralls setuptools setuptools_scm pep517 snoop
         pip install .[tests]
         coverage run --source python_runner -m pytest
         coverage report -m

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ venv
 *.pyo
 __pycache__
 .coverage
-tests/my_program.py
+# Ignore default file no matter where tests are run
+**/my_program.py

--- a/python_runner/runner.py
+++ b/python_runner/runner.py
@@ -91,17 +91,17 @@ class Runner:
                 self.output("traceback", **self.serialize_traceback(e))
         self.post_run()
 
-    def run(self, source_code, mode="exec", **kwargs):
+    def run(self, source_code, mode="exec"):
         code_obj = self.pre_run(source_code, mode=mode)
         with self._execute_context():
             if code_obj:
-                return self.execute(code_obj, mode=mode, **kwargs)
+                return self.execute(code_obj, mode=mode)
 
-    async def run_async(self, source_code, mode="exec", top_level_await=True, **kwargs):
+    async def run_async(self, source_code, mode="exec", top_level_await=True):
         code_obj = self.pre_run(source_code, mode, top_level_await=top_level_await)
         with self._execute_context():
             if code_obj:
-                result = self.execute(code_obj, mode=mode, **kwargs)
+                result = self.execute(code_obj, mode=mode)
                 while isinstance(result, Awaitable):
                     result = await result
                 return result

--- a/python_runner/runner.py
+++ b/python_runner/runner.py
@@ -68,7 +68,8 @@ class Runner:
     def snoop_config(self, out=None, color=False):
         import snoop
         if out is None:
-            out = SysStream("snoop", self.output_buffer)
+            from .snoop import SnoopStream
+            out = SnoopStream(self.output_buffer)
         return snoop.Config(
             columns=(),
             out=out,

--- a/python_runner/runner.py
+++ b/python_runner/runner.py
@@ -65,11 +65,22 @@ class Runner:
     def output(self, output_type, text, **extra):
         return self.output_buffer.put(output_type, text, **extra)
 
-    def execute(self, code_obj, mode=None, **kwargs):  # noqa
+    def snoop_config(self, out=None, color=False):
+        import snoop
+        if out is None:
+            out = SysStream("snoop", self.output_buffer)
+        return snoop.Config(
+            columns=(),
+            out=out,
+            color=color,
+        )
+
+    def execute(self, code_obj, mode=None):  # noqa
         if mode == "snoop":
             from .snoop import exec_snoop
-            exec_snoop(self, code_obj, out=SysStream("snoop", self.output_buffer), **kwargs)
-        return eval(code_obj, self.console.locals)  # noqa
+            exec_snoop(self, code_obj, config=self.snoop_config())
+        else:
+            return eval(code_obj, self.console.locals)  # noqa
 
     @contextmanager
     def _execute_context(self):

--- a/python_runner/runner.py
+++ b/python_runner/runner.py
@@ -69,9 +69,7 @@ class Runner:
         if mode == "snoop":
             from .snoop import exec_snoop, SnoopStream
             default_config = dict(columns=(), out=SnoopStream(self.output_buffer), color=False)
-            if snoop_config is not None:
-               default_config = default_config | snoop_config
-            exec_snoop(self, code_obj, snoop_config=default_config)
+            exec_snoop(self, code_obj, snoop_config=default_config | (snoop_config or {}))
         else:
             return eval(code_obj, self.console.locals)  # noqa
 

--- a/python_runner/runner.py
+++ b/python_runner/runner.py
@@ -68,9 +68,10 @@ class Runner:
     def execute(self, code_obj, mode=None, snoop_config=None):  # noqa
         if mode == "snoop":
             from .snoop import exec_snoop, SnoopStream
-            if snoop_config is None:
-               snoop_config = dict(out=SnoopStream(self.output_buffer), color=False)
-            exec_snoop(self, code_obj, snoop_config=snoop_config)
+            default_config = dict(columns=(), out=SnoopStream(self.output_buffer), color=False)
+            if snoop_config is not None:
+               default_config = default_config | snoop_config
+            exec_snoop(self, code_obj, snoop_config=default_config)
         else:
             return eval(code_obj, self.console.locals)  # noqa
 

--- a/python_runner/runner.py
+++ b/python_runner/runner.py
@@ -10,7 +10,7 @@ from collections.abc import Awaitable
 from contextlib import contextmanager
 from types import ModuleType
 
-from .output import OutputBuffer, SysStream
+from .output import OutputBuffer
 
 log = logging.getLogger(__name__)
 

--- a/python_runner/snoop.py
+++ b/python_runner/snoop.py
@@ -23,7 +23,7 @@ class SnoopStream(SysStream):
     def flush(self):
         pass
 
-def exec_snoop(runner, code_obj, config):
+def exec_snoop(runner, code_obj, snoop_config=None):
     class PatchedFrameInfo(snoop.tracer.FrameInfo):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
@@ -32,7 +32,14 @@ def exec_snoop(runner, code_obj, config):
     snoop.tracer.FrameInfo = PatchedFrameInfo
 
     snoop.formatting.Source._class_local('__source_cache', {}).pop(runner.filename, None)
-
+    default_config = dict(
+        columns=(),
+        out=sys.stdout,
+        color=True,
+    )
+    if snoop_config is not None: # Merge options, overriding when appropriate
+        default_config = default_config | snoop_config
+    config = snoop.Config(**default_config)
     tracer = config.snoop()
     tracer.variable_whitelist = set()
     for node in ast.walk(ast.parse(runner.source_code)):

--- a/python_runner/snoop.py
+++ b/python_runner/snoop.py
@@ -23,7 +23,7 @@ class SnoopStream(SysStream):
     def flush(self):
         pass
 
-def exec_snoop(runner, code_obj, snoop_config=None):
+def exec_snoop(runner, code_obj, snoop_config):
     class PatchedFrameInfo(snoop.tracer.FrameInfo):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
@@ -32,14 +32,7 @@ def exec_snoop(runner, code_obj, snoop_config=None):
     snoop.tracer.FrameInfo = PatchedFrameInfo
 
     snoop.formatting.Source._class_local('__source_cache', {}).pop(runner.filename, None)
-    default_config = dict(
-        columns=(),
-        out=sys.stdout,
-        color=True,
-    )
-    if snoop_config is not None: # Merge options, overriding when appropriate
-        default_config = default_config | snoop_config
-    config = snoop.Config(**default_config)
+    config = snoop.Config(**snoop_config)
     tracer = config.snoop()
     tracer.variable_whitelist = set()
     for node in ast.walk(ast.parse(runner.source_code)):

--- a/python_runner/snoop.py
+++ b/python_runner/snoop.py
@@ -1,7 +1,6 @@
 import ast
 import inspect
 import os
-import sys
 
 import snoop
 import snoop.formatting
@@ -21,10 +20,11 @@ class SnoopStream(SysStream):
         super().__init__("snoop", output_buffer)
 
     def flush(self):
-        pass
+        pass  # pragma: no cover
+
 
 def exec_snoop(runner, code_obj, snoop_config):
-    class PatchedFrameInfo(snoop.tracer.FrameInfo):
+    class PatchedFrameInfo(snoop.tracer.FrameInfo):  # pragma: no cover (happens inside snoop's trace function)
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
             self.is_ipython_cell = self.frame.f_code == code_obj

--- a/python_runner/snoop.py
+++ b/python_runner/snoop.py
@@ -15,7 +15,7 @@ snoop.tracer.internal_directories += (
 )
 
 
-def exec_snoop(runner, code_obj, out=sys.stdout, color=True):
+def exec_snoop(runner, code_obj, config=None):
     class PatchedFrameInfo(snoop.tracer.FrameInfo):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
@@ -25,10 +25,10 @@ def exec_snoop(runner, code_obj, out=sys.stdout, color=True):
 
     snoop.formatting.Source._class_local('__source_cache', {}).pop(runner.filename, None)
 
-    config = snoop.Config(
+    config = config or snoop.Config(
         columns=(),
-        out=out,
-        color=color,
+        out=sys.stdout,
+        color=True,
     )
     tracer = config.snoop()
     tracer.variable_whitelist = set()
@@ -39,9 +39,6 @@ def exec_snoop(runner, code_obj, out=sys.stdout, color=True):
     tracer.target_codes.add(code_obj)
 
     def find_code(root_code):
-        """
-        Trace all functions recursively, like trace_module_deep.
-        """
         for sub_code_obj in root_code.co_consts:
             if not inspect.iscode(sub_code_obj):
                 continue

--- a/python_runner/snoop.py
+++ b/python_runner/snoop.py
@@ -1,0 +1,55 @@
+import ast
+import inspect
+import os
+import sys
+
+import snoop
+import snoop.formatting
+import snoop.tracer
+
+internal_dir = os.path.dirname(os.path.dirname(
+    (lambda: 0).__code__.co_filename
+))
+snoop.tracer.internal_directories += (
+    internal_dir,
+)
+
+
+def exec_snoop(runner, code_obj, out=sys.stdout, color=True):
+    class PatchedFrameInfo(snoop.tracer.FrameInfo):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.is_ipython_cell = self.frame.f_code == code_obj
+
+    snoop.tracer.FrameInfo = PatchedFrameInfo
+
+    snoop.formatting.Source._class_local('__source_cache', {}).pop(runner.filename, None)
+
+    config = snoop.Config(
+        columns=(),
+        out=out,
+        color=color,
+    )
+    tracer = config.snoop()
+    tracer.variable_whitelist = set()
+    for node in ast.walk(ast.parse(runner.source_code)):
+        if isinstance(node, ast.Name):
+            name = node.id
+            tracer.variable_whitelist.add(name)
+    tracer.target_codes.add(code_obj)
+
+    def find_code(root_code):
+        """
+        Trace all functions recursively, like trace_module_deep.
+        """
+        for sub_code_obj in root_code.co_consts:
+            if not inspect.iscode(sub_code_obj):
+                continue
+
+            find_code(sub_code_obj)
+            tracer.target_codes.add(sub_code_obj)
+
+    find_code(code_obj)
+
+    with tracer:
+        runner.execute(code_obj)

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,9 @@ include_package_data = True
 tests_require = pytest
 
 [options.extras_require]
-tests = pytest
+tests = 
+    pytest
+    snoop
 
 [coverage:run]
 relative_files = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,9 @@ classifiers =
 packages = python_runner
 setup_requires = setuptools>=44; setuptools_scm[toml]>=3.4.3
 include_package_data = True
-tests_require = pytest
+tests_require = 
+    pytest
+    snoop
 
 [options.extras_require]
 tests = 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -591,19 +591,12 @@ def test_invalid_sleep():
 def test_snoop():
     code = dedent(
         """
-    def factorial(x):
-        if x <= 1:
-            return x
-        return x * factorial(x - 1)
-
-    factorial(5)
+    x = 5
+    x *= 2
         """)
-    global events
-    events = []
-    runner = MyRunner(callback=default_callback)
-    result = runner.run(code, mode="snoop", color=False)
-    assert events
-    for (event_type, data) in events:
-        assert event_type == "output"
-        for part in data["parts"]:
-            assert part["type"] == "snoop"
+    check_simple(code, [
+        ('output', {'parts': [{'text': '','type': 'snoop'}]}),
+        ('output', {'parts': [{'text': '    2 | x = 5\n', 'type': 'snoop'}]}),
+        ('output', {'parts': [{'text': '    3 | x *= 2\n', 'type': 'snoop'}]}),
+        ('output', {'parts': [{'text': ' ...... x = 10\n', 'type': 'snoop'}]})
+    ], mode="snoop")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -10,8 +10,6 @@ import pytest
 from python_runner import PatchedStdinRunner, PatchedSleepRunner
 from python_runner.output import OutputBuffer
 
-OutputBuffer.flush_time = 0.1
-
 
 class MyRunner(PatchedStdinRunner):
     def serialize_traceback(self, exc):
@@ -32,7 +30,15 @@ def default_callback(event_type, data):
         return f"input: {len(events)}"
 
 
-def check_simple(source_code, expected_events, mode="exec", runner=None):
+def check_simple(
+    source_code,
+    expected_events,
+    mode="exec",
+    runner=None,
+    flush_time=OutputBuffer.flush_time,
+):
+    OutputBuffer.flush_time = flush_time
+
     global events
     events = []
 
@@ -439,6 +445,7 @@ def test_flush_time():
             ("output", {"parts": [{"type": "stdout", "text": "1\n2\n3"}]}),
             ("output", {"parts": [{"type": "stdout", "text": "\n4\n"}]}),
         ],
+        flush_time=0.1,
     )
 
 
@@ -600,7 +607,6 @@ def test_snoop():
     double(5)
         """)
     check_simple(code, [
-        ('output', {'parts': [{'type': 'snoop', 'text': ''}]}),
         ('output', {'parts': [{'type': 'snoop', 'text': (
             '    2 | def double(x):\n'
             '    5 | double(5)\n'  

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -602,8 +602,14 @@ def test_snoop():
     check_simple(code, [
         ('output', {'parts': [{'type': 'snoop', 'text': ''}]}),
         ('output', {'parts': [{'type': 'snoop', 'text': (
-            '    2 | def double(x):\n    5 | double(5)\n'  
-           f'     >>> Call to double in File "{filename}", line 2\n     ...... x = 5\n        2 | def double(x):\n        3 |   '
-            '  return 2*x\n     <<< Return value from double: 10\n    5 | double(5)\n'
+            '    2 | def double(x):\n'
+            '    5 | double(5)\n'  
+           f'     >>> Call to double in File "{filename}", line 2\n'
+            '     ...... x = 5\n'
+            '        2 | def double(x):\n'
+            '        3 |   '
+            '  return 2*x\n'
+            '     <<< Return value from double: 10\n'
+            '    5 | double(5)\n'
             )}]})
         ], mode="snoop")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -587,3 +587,23 @@ def test_invalid_sleep():
                 with pytest.raises(type(e)):
                     runner.sleep(arg)
                 raise
+
+def test_snoop():
+    code = dedent(
+        """
+    def factorial(x):
+        if x <= 1:
+            return x
+        return x * factorial(x - 1)
+
+    factorial(5)
+        """)
+    global events
+    events = []
+    runner = MyRunner(callback=default_callback)
+    result = runner.run(code, mode="snoop", color=False)
+    assert events
+    for (event_type, data) in events:
+        assert event_type == "output"
+        for part in data["parts"]:
+            assert part["type"] == "snoop"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -607,8 +607,7 @@ def test_snoop():
            f'     >>> Call to double in File "{filename}", line 2\n'
             '     ...... x = 5\n'
             '        2 | def double(x):\n'
-            '        3 |   '
-            '  return 2*x\n'
+            '        3 |     return 2*x\n'
             '     <<< Return value from double: 10\n'
             '    5 | double(5)\n'
             )}]})


### PR DESCRIPTION
Adds features discussed in https://github.com/dodona-edu/papyros/pull/109#issuecomment-1095446841
Extra:
run and run_async accept arbitrary kwargs which are passed to execute, which can then be passed to e.g. exec_snoop to set Snoop config values.

I wasn't entirely sure what to do with the internal directory updates you did in futurecoder. Is this something we want in general, to also trace our inner workings? I don't see how I would want that for example in Papyros, or is that needed to be able to trace the methods in the user's file?